### PR TITLE
Add org-sync multi-module skeleton

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,63 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.2.5' apply false
+    id 'io.spring.dependency-management' version '1.1.4' apply false
+}
+
+group = 'org.orgsync'
+version = '0.1.0-SNAPSHOT'
+
+subprojects {
+    apply plugin: 'java'
+
+    group = rootProject.group
+    version = rootProject.version
+
+    repositories {
+        mavenCentral()
+    }
+
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    tasks.withType(JavaCompile).configureEach {
+        options.encoding = 'UTF-8'
+    }
+}
+
+project(':org-sync-spring') {
+    dependencies {
+        api project(':org-sync-core')
+        implementation 'org.springframework:spring-context:6.1.6'
+    }
+}
+
+project(':org-sync-boot-starter') {
+    apply plugin: 'io.spring.dependency-management'
+
+    dependencies {
+        api project(':org-sync-spring')
+        implementation 'org.springframework.boot:spring-boot-autoconfigure:3.2.5'
+    }
+}
+
+project(':org-sync-boot-sample') {
+    apply plugin: 'org.springframework.boot'
+    apply plugin: 'io.spring.dependency-management'
+
+    dependencies {
+        implementation project(':org-sync-boot-starter')
+        implementation 'org.springframework.boot:spring-boot-starter:3.2.5'
+        implementation 'org.apache.commons:commons-dbcp2:2.12.0'
+    }
+}
+
+project(':org-sync-spring-sample') {
+    dependencies {
+        implementation project(':org-sync-spring')
+        implementation 'org.springframework:spring-context:6.1.6'
+        implementation 'org.apache.commons:commons-dbcp2:2.12.0'
+    }
+}

--- a/org-sync-boot-sample/src/main/java/org/orgsync/bootsample/OrgSyncBootSampleApplication.java
+++ b/org-sync-boot-sample/src/main/java/org/orgsync/bootsample/OrgSyncBootSampleApplication.java
@@ -1,0 +1,78 @@
+package org.orgsync.bootsample;
+
+import org.orgsync.core.DomainEvent;
+import org.orgsync.core.DomainEventPublisher;
+import org.orgsync.core.OrgChartClient;
+import org.orgsync.core.SyncEngine;
+import org.orgsync.core.SyncResponse;
+import org.orgsync.core.SyncStateRepository;
+import org.orgsync.core.YamlSyncSpec;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+import javax.sql.DataSource;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+@SpringBootApplication
+public class OrgSyncBootSampleApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OrgSyncBootSampleApplication.class, args);
+    }
+
+    @Bean
+    CommandLineRunner runSync(SyncEngine syncEngine) {
+        return args -> syncEngine.synchronizeCompany("sample-company");
+    }
+
+    @Bean
+    OrgChartClient orgChartClient() {
+        return (companyId, sinceCursor) -> new SyncResponse(false, "cursor-1", Set.of("user"), Collections.emptyList());
+    }
+
+    @Bean
+    SyncStateRepository syncStateRepository() {
+        return new SyncStateRepository() {
+            private String cursor;
+
+            @Override
+            public Optional<String> loadCursor(String companyId) {
+                return Optional.ofNullable(cursor);
+            }
+
+            @Override
+            public void saveCursor(String companyId, String nextCursor) {
+                this.cursor = nextCursor;
+            }
+        };
+    }
+
+    @Bean
+    YamlSyncSpec yamlSyncSpec() {
+        return new YamlSyncSpec(Collections.emptyMap());
+    }
+
+    @Bean
+    DomainEventPublisher domainEventPublisher() {
+        return new DomainEventPublisher() {
+            @Override
+            public void publishDomainEvent(DomainEvent event) {
+                System.out.println("Domain event: " + event.type());
+            }
+
+            @Override
+            public void publishSnapshotApplied(String companyId, String cursor, Iterable<String> domains) {
+                System.out.println("Snapshot applied for " + companyId + " at " + cursor);
+            }
+        };
+    }
+
+    @Bean
+    DataSource dataSource() {
+        return new org.apache.commons.dbcp2.BasicDataSource();
+    }
+}

--- a/org-sync-boot-starter/src/main/java/org/orgsync/boot/OrgSyncAutoConfiguration.java
+++ b/org-sync-boot-starter/src/main/java/org/orgsync/boot/OrgSyncAutoConfiguration.java
@@ -1,0 +1,67 @@
+package org.orgsync.boot;
+
+import org.orgsync.core.DomainEventPublisher;
+import org.orgsync.core.JdbcApplier;
+import org.orgsync.core.LockManager;
+import org.orgsync.core.OrgChartClient;
+import org.orgsync.core.SpecValidator;
+import org.orgsync.core.SyncEngine;
+import org.orgsync.core.SyncStateRepository;
+import org.orgsync.core.YamlSyncSpec;
+import org.orgsync.spring.InMemoryLockManager;
+import org.orgsync.spring.OrgSyncConfiguration;
+import org.orgsync.spring.SpringDomainEventPublisher;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+import javax.sql.DataSource;
+
+/**
+ * Spring Boot auto-configuration that exposes the sync engine and defaults.
+ */
+@AutoConfiguration
+@ConditionalOnClass(SyncEngine.class)
+@Import(OrgSyncConfiguration.class)
+public class OrgSyncAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public LockManager lockManager() {
+        return new InMemoryLockManager();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public DomainEventPublisher domainEventPublisher(ApplicationEventPublisher publisher) {
+        return new SpringDomainEventPublisher(publisher);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnBean({DataSource.class, YamlSyncSpec.class})
+    public JdbcApplier jdbcApplier(DataSource dataSource, YamlSyncSpec syncSpec) {
+        return new JdbcApplier(dataSource, syncSpec);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SpecValidator specValidator() {
+        return new SpecValidator();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SyncEngine syncEngine(OrgChartClient client,
+                                 SyncStateRepository stateRepository,
+                                 JdbcApplier jdbcApplier,
+                                 DomainEventPublisher eventPublisher,
+                                 LockManager lockManager) {
+        return new SyncEngine(client, stateRepository, jdbcApplier, eventPublisher, lockManager);
+    }
+}

--- a/org-sync-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/org-sync-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.orgsync.boot.OrgSyncAutoConfiguration

--- a/org-sync-core/src/main/java/org/orgsync/core/DomainEvent.java
+++ b/org-sync-core/src/main/java/org/orgsync/core/DomainEvent.java
@@ -1,0 +1,46 @@
+package org.orgsync.core;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Simplified domain event representation emitted after delta processing.
+ */
+public class DomainEvent {
+
+    public enum Type {
+        ENTITY_CREATED,
+        ENTITY_UPDATED,
+        ENTITY_DELETED,
+        FIELD_UPDATED,
+        SNAPSHOT_APPLIED
+    }
+
+    private final Type type;
+    private final String domain;
+    private final String key;
+    private final Map<String, Object> payload;
+
+    public DomainEvent(Type type, String domain, String key, Map<String, Object> payload) {
+        this.type = Objects.requireNonNull(type, "type");
+        this.domain = Objects.requireNonNull(domain, "domain");
+        this.key = Objects.requireNonNull(key, "key");
+        this.payload = payload;
+    }
+
+    public Type type() {
+        return type;
+    }
+
+    public String domain() {
+        return domain;
+    }
+
+    public String key() {
+        return key;
+    }
+
+    public Map<String, Object> payload() {
+        return payload;
+    }
+}

--- a/org-sync-core/src/main/java/org/orgsync/core/DomainEventPublisher.java
+++ b/org-sync-core/src/main/java/org/orgsync/core/DomainEventPublisher.java
@@ -1,0 +1,11 @@
+package org.orgsync.core;
+
+/**
+ * Publishes synchronization domain events to the hosting application.
+ */
+public interface DomainEventPublisher {
+
+    void publishDomainEvent(DomainEvent event);
+
+    void publishSnapshotApplied(String companyId, String cursor, Iterable<String> domains);
+}

--- a/org-sync-core/src/main/java/org/orgsync/core/JdbcApplier.java
+++ b/org-sync-core/src/main/java/org/orgsync/core/JdbcApplier.java
@@ -1,0 +1,34 @@
+package org.orgsync.core;
+
+import javax.sql.DataSource;
+import java.util.Objects;
+
+/**
+ * Applies snapshot or delta responses into JDBC-accessible storage.
+ */
+public class JdbcApplier {
+
+    private final DataSource dataSource;
+    private final YamlSyncSpec syncSpec;
+
+    public JdbcApplier(DataSource dataSource, YamlSyncSpec syncSpec) {
+        this.dataSource = Objects.requireNonNull(dataSource, "dataSource");
+        this.syncSpec = Objects.requireNonNull(syncSpec, "syncSpec");
+    }
+
+    public void applySnapshot(String companyId, SyncResponse response) {
+        // TODO: implement chunked snapshot writes and validation
+    }
+
+    public void applyDelta(String companyId, SyncResponse response) {
+        // TODO: implement upsert/delete operations and event mapping
+    }
+
+    public DataSource getDataSource() {
+        return dataSource;
+    }
+
+    public YamlSyncSpec getSyncSpec() {
+        return syncSpec;
+    }
+}

--- a/org-sync-core/src/main/java/org/orgsync/core/LockManager.java
+++ b/org-sync-core/src/main/java/org/orgsync/core/LockManager.java
@@ -1,0 +1,9 @@
+package org.orgsync.core;
+
+/**
+ * Coordinates company-level locking to ensure idempotent processing.
+ */
+public interface LockManager {
+
+    void withLock(String companyId, Runnable runnable);
+}

--- a/org-sync-core/src/main/java/org/orgsync/core/OrgChartClient.java
+++ b/org-sync-core/src/main/java/org/orgsync/core/OrgChartClient.java
@@ -1,0 +1,15 @@
+package org.orgsync.core;
+
+/**
+ * Fetches snapshot or delta data from the upstream org chart server.
+ */
+public interface OrgChartClient {
+
+    /**
+     * Retrieves changes after the given cursor for a company.
+     * @param companyId company identifier
+     * @param sinceCursor last processed cursor or {@code null} when starting
+     * @return snapshot or delta response
+     */
+    SyncResponse fetchChanges(String companyId, String sinceCursor);
+}

--- a/org-sync-core/src/main/java/org/orgsync/core/SpecValidator.java
+++ b/org-sync-core/src/main/java/org/orgsync/core/SpecValidator.java
@@ -1,0 +1,27 @@
+package org.orgsync.core;
+
+import java.util.Map;
+
+/**
+ * Performs basic validations on the parsed YAML sync specification.
+ */
+public class SpecValidator {
+
+    public void validate(YamlSyncSpec spec) {
+        if (spec.getDomains().isEmpty()) {
+            throw new IllegalArgumentException("At least one domain mapping must be provided");
+        }
+        for (Map.Entry<String, YamlSyncSpec.DomainProjection> entry : spec.getDomains().entrySet()) {
+            validateDomain(entry.getKey(), entry.getValue());
+        }
+    }
+
+    private void validateDomain(String domain, YamlSyncSpec.DomainProjection projection) {
+        if (projection.table() == null || projection.table().isBlank()) {
+            throw new IllegalArgumentException("Domain " + domain + " requires a target table");
+        }
+        if (projection.fields() == null || projection.fields().isEmpty()) {
+            throw new IllegalArgumentException("Domain " + domain + " requires at least one field mapping");
+        }
+    }
+}

--- a/org-sync-core/src/main/java/org/orgsync/core/SyncEngine.java
+++ b/org-sync-core/src/main/java/org/orgsync/core/SyncEngine.java
@@ -1,0 +1,54 @@
+package org.orgsync.core;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Coordinates synchronization by pulling data from the org chart server and applying it
+ * to a downstream database.
+ */
+public class SyncEngine {
+
+    private final OrgChartClient client;
+    private final SyncStateRepository stateRepository;
+    private final JdbcApplier jdbcApplier;
+    private final DomainEventPublisher eventPublisher;
+    private final LockManager lockManager;
+
+    public SyncEngine(OrgChartClient client,
+                      SyncStateRepository stateRepository,
+                      JdbcApplier jdbcApplier,
+                      DomainEventPublisher eventPublisher,
+                      LockManager lockManager) {
+        this.client = Objects.requireNonNull(client, "client");
+        this.stateRepository = Objects.requireNonNull(stateRepository, "stateRepository");
+        this.jdbcApplier = Objects.requireNonNull(jdbcApplier, "jdbcApplier");
+        this.eventPublisher = Objects.requireNonNull(eventPublisher, "eventPublisher");
+        this.lockManager = Objects.requireNonNull(lockManager, "lockManager");
+    }
+
+    public void synchronizeCompany(String companyId) {
+        lockManager.withLock(companyId, () -> doSynchronize(companyId));
+    }
+
+    private void doSynchronize(String companyId) {
+        Optional<String> cursor = stateRepository.loadCursor(companyId);
+        SyncResponse response = client.fetchChanges(companyId, cursor.orElse(null));
+        if (response.needSnapshot()) {
+            applySnapshot(companyId, response);
+        } else {
+            applyDelta(companyId, response);
+        }
+        stateRepository.saveCursor(companyId, response.nextCursor());
+    }
+
+    private void applySnapshot(String companyId, SyncResponse response) {
+        jdbcApplier.applySnapshot(companyId, response);
+        eventPublisher.publishSnapshotApplied(companyId, response.nextCursor(), response.processedDomains());
+    }
+
+    private void applyDelta(String companyId, SyncResponse response) {
+        jdbcApplier.applyDelta(companyId, response);
+        response.events().forEach(eventPublisher::publishDomainEvent);
+    }
+}

--- a/org-sync-core/src/main/java/org/orgsync/core/SyncResponse.java
+++ b/org-sync-core/src/main/java/org/orgsync/core/SyncResponse.java
@@ -1,0 +1,39 @@
+package org.orgsync.core;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Represents either a snapshot or delta response from the org chart service.
+ */
+public class SyncResponse {
+
+    private final boolean needSnapshot;
+    private final String nextCursor;
+    private final Set<String> processedDomains;
+    private final List<DomainEvent> events;
+
+    public SyncResponse(boolean needSnapshot, String nextCursor, Set<String> processedDomains, List<DomainEvent> events) {
+        this.needSnapshot = needSnapshot;
+        this.nextCursor = nextCursor;
+        this.processedDomains = processedDomains == null ? Collections.emptySet() : Collections.unmodifiableSet(processedDomains);
+        this.events = events == null ? Collections.emptyList() : Collections.unmodifiableList(events);
+    }
+
+    public boolean needSnapshot() {
+        return needSnapshot;
+    }
+
+    public String nextCursor() {
+        return nextCursor;
+    }
+
+    public Set<String> processedDomains() {
+        return processedDomains;
+    }
+
+    public List<DomainEvent> events() {
+        return events;
+    }
+}

--- a/org-sync-core/src/main/java/org/orgsync/core/SyncStateRepository.java
+++ b/org-sync-core/src/main/java/org/orgsync/core/SyncStateRepository.java
@@ -1,0 +1,13 @@
+package org.orgsync.core;
+
+import java.util.Optional;
+
+/**
+ * Stores and retrieves synchronization cursors.
+ */
+public interface SyncStateRepository {
+
+    Optional<String> loadCursor(String companyId);
+
+    void saveCursor(String companyId, String nextCursor);
+}

--- a/org-sync-core/src/main/java/org/orgsync/core/YamlSpecLoader.java
+++ b/org-sync-core/src/main/java/org/orgsync/core/YamlSpecLoader.java
@@ -1,0 +1,22 @@
+package org.orgsync.core;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * Loads YAML projection specifications from disk.
+ */
+public class YamlSpecLoader {
+
+    public YamlSyncSpec load(Path path) {
+        try (InputStream inputStream = Files.newInputStream(path)) {
+            // TODO: wire a YAML parser such as SnakeYAML to populate the spec
+            return new YamlSyncSpec(Map.of());
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to load sync spec from " + path, e);
+        }
+    }
+}

--- a/org-sync-core/src/main/java/org/orgsync/core/YamlSyncSpec.java
+++ b/org-sync-core/src/main/java/org/orgsync/core/YamlSyncSpec.java
@@ -1,0 +1,28 @@
+package org.orgsync.core;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Parsed representation of the YAML-based projection specification.
+ */
+public class YamlSyncSpec {
+
+    private final Map<String, DomainProjection> domains;
+
+    public YamlSyncSpec(Map<String, DomainProjection> domains) {
+        this.domains = domains == null ? Collections.emptyMap() : Collections.unmodifiableMap(domains);
+    }
+
+    public Map<String, DomainProjection> getDomains() {
+        return domains;
+    }
+
+    public record DomainProjection(String table, Map<String, String> fields) {
+        public DomainProjection {
+            Objects.requireNonNull(table, "table");
+            fields = fields == null ? Collections.emptyMap() : Collections.unmodifiableMap(fields);
+        }
+    }
+}

--- a/org-sync-spring-sample/src/main/java/org/orgsync/springsample/OrgSyncSpringSample.java
+++ b/org-sync-spring-sample/src/main/java/org/orgsync/springsample/OrgSyncSpringSample.java
@@ -1,0 +1,78 @@
+package org.orgsync.springsample;
+
+import org.orgsync.core.DomainEvent;
+import org.orgsync.core.DomainEventPublisher;
+import org.orgsync.core.LockManager;
+import org.orgsync.core.OrgChartClient;
+import org.orgsync.core.SyncEngine;
+import org.orgsync.core.SyncResponse;
+import org.orgsync.core.SyncStateRepository;
+import org.orgsync.core.YamlSyncSpec;
+import org.orgsync.spring.InMemoryLockManager;
+import org.orgsync.spring.OrgSyncConfiguration;
+import org.orgsync.spring.SpringDomainEventPublisher;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.GenericApplicationContext;
+
+import javax.sql.DataSource;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+public class OrgSyncSpringSample {
+
+    public static void main(String[] args) {
+        try (GenericApplicationContext context = new AnnotationConfigApplicationContext(SampleConfig.class, OrgSyncConfiguration.class)) {
+            SyncEngine engine = context.getBean(SyncEngine.class);
+            engine.synchronizeCompany("spring-sample");
+        }
+    }
+
+    @Configuration
+    static class SampleConfig {
+
+        @Bean
+        public OrgChartClient orgChartClient() {
+            return (companyId, sinceCursor) -> new SyncResponse(false, "cursor-1", Set.of("user"), Collections.emptyList());
+        }
+
+        @Bean
+        public SyncStateRepository syncStateRepository() {
+            return new SyncStateRepository() {
+                private String cursor;
+
+                @Override
+                public Optional<String> loadCursor(String companyId) {
+                    return Optional.ofNullable(cursor);
+                }
+
+                @Override
+                public void saveCursor(String companyId, String nextCursor) {
+                    this.cursor = nextCursor;
+                }
+            };
+        }
+
+        @Bean
+        public YamlSyncSpec yamlSyncSpec() {
+            return new YamlSyncSpec(Collections.emptyMap());
+        }
+
+        @Bean
+        public DomainEventPublisher domainEventPublisher(org.springframework.context.ApplicationEventPublisher publisher) {
+            return new SpringDomainEventPublisher(publisher);
+        }
+
+        @Bean
+        public LockManager lockManager() {
+            return new InMemoryLockManager();
+        }
+
+        @Bean
+        public DataSource dataSource() {
+            return new org.apache.commons.dbcp2.BasicDataSource();
+        }
+    }
+}

--- a/org-sync-spring/src/main/java/org/orgsync/spring/InMemoryLockManager.java
+++ b/org-sync-spring/src/main/java/org/orgsync/spring/InMemoryLockManager.java
@@ -1,0 +1,26 @@
+package org.orgsync.spring;
+
+import org.orgsync.core.LockManager;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Simple in-memory lock manager to demonstrate serialization by company identifier.
+ */
+public class InMemoryLockManager implements LockManager {
+
+    private final Map<String, ReentrantLock> locks = new ConcurrentHashMap<>();
+
+    @Override
+    public void withLock(String companyId, Runnable runnable) {
+        ReentrantLock lock = locks.computeIfAbsent(companyId, key -> new ReentrantLock());
+        lock.lock();
+        try {
+            runnable.run();
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/org-sync-spring/src/main/java/org/orgsync/spring/OrgSyncConfiguration.java
+++ b/org-sync-spring/src/main/java/org/orgsync/spring/OrgSyncConfiguration.java
@@ -1,0 +1,53 @@
+package org.orgsync.spring;
+
+import org.orgsync.core.DomainEventPublisher;
+import org.orgsync.core.JdbcApplier;
+import org.orgsync.core.LockManager;
+import org.orgsync.core.OrgChartClient;
+import org.orgsync.core.SpecValidator;
+import org.orgsync.core.SyncEngine;
+import org.orgsync.core.SyncStateRepository;
+import org.orgsync.core.YamlSpecLoader;
+import org.orgsync.core.YamlSyncSpec;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+import java.nio.file.Path;
+
+/**
+ * Core Spring configuration that wires the sync engine and supporting components.
+ */
+@Configuration
+public class OrgSyncConfiguration {
+
+    @Bean
+    public DomainEventPublisher domainEventPublisher(org.springframework.context.ApplicationEventPublisher publisher) {
+        return new SpringDomainEventPublisher(publisher);
+    }
+
+    @Bean
+    public YamlSyncSpec yamlSyncSpec() {
+        // TODO: externalize specification path to configuration
+        return new YamlSpecLoader().load(Path.of("org-sync.yaml"));
+    }
+
+    @Bean
+    public SpecValidator specValidator() {
+        return new SpecValidator();
+    }
+
+    @Bean
+    public JdbcApplier jdbcApplier(DataSource dataSource, YamlSyncSpec yamlSyncSpec) {
+        return new JdbcApplier(dataSource, yamlSyncSpec);
+    }
+
+    @Bean
+    public SyncEngine syncEngine(OrgChartClient client,
+                                 SyncStateRepository stateRepository,
+                                 JdbcApplier jdbcApplier,
+                                 DomainEventPublisher eventPublisher,
+                                 LockManager lockManager) {
+        return new SyncEngine(client, stateRepository, jdbcApplier, eventPublisher, lockManager);
+    }
+}

--- a/org-sync-spring/src/main/java/org/orgsync/spring/SnapshotAppliedEvent.java
+++ b/org-sync-spring/src/main/java/org/orgsync/spring/SnapshotAppliedEvent.java
@@ -1,0 +1,31 @@
+package org.orgsync.spring;
+
+import java.util.List;
+
+/**
+ * Spring application event describing a completed snapshot application.
+ */
+public class SnapshotAppliedEvent {
+
+    private final String companyId;
+    private final String cursor;
+    private final List<String> domains;
+
+    public SnapshotAppliedEvent(String companyId, String cursor, Iterable<String> domains) {
+        this.companyId = companyId;
+        this.cursor = cursor;
+        this.domains = domains == null ? List.of() : List.copyOf(domains);
+    }
+
+    public String getCompanyId() {
+        return companyId;
+    }
+
+    public String getCursor() {
+        return cursor;
+    }
+
+    public List<String> getDomains() {
+        return domains;
+    }
+}

--- a/org-sync-spring/src/main/java/org/orgsync/spring/SpringDomainEventPublisher.java
+++ b/org-sync-spring/src/main/java/org/orgsync/spring/SpringDomainEventPublisher.java
@@ -1,0 +1,29 @@
+package org.orgsync.spring;
+
+import org.orgsync.core.DomainEvent;
+import org.orgsync.core.DomainEventPublisher;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.Objects;
+
+/**
+ * Bridges {@link DomainEventPublisher} to Spring's {@link ApplicationEventPublisher}.
+ */
+public class SpringDomainEventPublisher implements DomainEventPublisher {
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    public SpringDomainEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+        this.applicationEventPublisher = Objects.requireNonNull(applicationEventPublisher, "applicationEventPublisher");
+    }
+
+    @Override
+    public void publishDomainEvent(DomainEvent event) {
+        applicationEventPublisher.publishEvent(event);
+    }
+
+    @Override
+    public void publishSnapshotApplied(String companyId, String cursor, Iterable<String> domains) {
+        applicationEventPublisher.publishEvent(new SnapshotAppliedEvent(companyId, cursor, domains));
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'org-sync'
+include 'org-sync-core', 'org-sync-spring', 'org-sync-boot-starter', 'org-sync-boot-sample', 'org-sync-spring-sample'


### PR DESCRIPTION
## Summary
- establish Gradle multi-module layout for core, Spring integration, Boot starter, and sample apps
- introduce draft sync engine interfaces and placeholder implementations based on the specification
- add Spring Boot auto-configuration and sample applications wiring demo dependencies

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a5f1522548327a576b9e163780c89)