### PR TITLE
Refactor core and spring modules into structured packages

### DIFF
--- a/org-sync-boot-sample/src/main/java/org/orgsync/bootsample/OrgSyncBootSampleApplication.java
+++ b/org-sync-boot-sample/src/main/java/org/orgsync/bootsample/OrgSyncBootSampleApplication.java
@@ -1,12 +1,12 @@
 package org.orgsync.bootsample;
 
-import org.orgsync.core.DomainEvent;
-import org.orgsync.core.DomainEventPublisher;
-import org.orgsync.core.OrgChartClient;
-import org.orgsync.core.SyncEngine;
-import org.orgsync.core.SyncResponse;
-import org.orgsync.core.SyncStateRepository;
-import org.orgsync.core.YamlSyncSpec;
+import org.orgsync.core.client.OrgChartClient;
+import org.orgsync.core.engine.SyncEngine;
+import org.orgsync.core.engine.SyncResponse;
+import org.orgsync.core.event.DomainEvent;
+import org.orgsync.core.event.DomainEventPublisher;
+import org.orgsync.core.state.SyncStateRepository;
+import org.orgsync.core.spec.YamlSyncSpec;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/org-sync-boot-starter/src/main/java/org/orgsync/boot/OrgSyncAutoConfiguration.java
+++ b/org-sync-boot-starter/src/main/java/org/orgsync/boot/OrgSyncAutoConfiguration.java
@@ -1,16 +1,16 @@
 package org.orgsync.boot;
 
-import org.orgsync.core.DomainEventPublisher;
-import org.orgsync.core.JdbcApplier;
-import org.orgsync.core.LockManager;
-import org.orgsync.core.OrgChartClient;
-import org.orgsync.core.SpecValidator;
-import org.orgsync.core.SyncEngine;
-import org.orgsync.core.SyncStateRepository;
-import org.orgsync.core.YamlSyncSpec;
-import org.orgsync.spring.InMemoryLockManager;
-import org.orgsync.spring.OrgSyncConfiguration;
-import org.orgsync.spring.SpringDomainEventPublisher;
+import org.orgsync.core.client.OrgChartClient;
+import org.orgsync.core.engine.SyncEngine;
+import org.orgsync.core.event.DomainEventPublisher;
+import org.orgsync.core.jdbc.JdbcApplier;
+import org.orgsync.core.lock.LockManager;
+import org.orgsync.core.spec.SpecValidator;
+import org.orgsync.core.spec.YamlSyncSpec;
+import org.orgsync.core.state.SyncStateRepository;
+import org.orgsync.spring.config.OrgSyncConfiguration;
+import org.orgsync.spring.event.SpringDomainEventPublisher;
+import org.orgsync.spring.lock.InMemoryLockManager;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;

--- a/org-sync-core/src/main/java/org/orgsync/core/client/OrgChartClient.java
+++ b/org-sync-core/src/main/java/org/orgsync/core/client/OrgChartClient.java
@@ -1,4 +1,6 @@
-package org.orgsync.core;
+package org.orgsync.core.client;
+
+import org.orgsync.core.engine.SyncResponse;
 
 /**
  * Fetches snapshot or delta data from the upstream org chart server.

--- a/org-sync-core/src/main/java/org/orgsync/core/engine/SyncEngine.java
+++ b/org-sync-core/src/main/java/org/orgsync/core/engine/SyncEngine.java
@@ -1,4 +1,10 @@
-package org.orgsync.core;
+package org.orgsync.core.engine;
+
+import org.orgsync.core.client.OrgChartClient;
+import org.orgsync.core.event.DomainEventPublisher;
+import org.orgsync.core.jdbc.JdbcApplier;
+import org.orgsync.core.lock.LockManager;
+import org.orgsync.core.state.SyncStateRepository;
 
 import java.util.Objects;
 import java.util.Optional;

--- a/org-sync-core/src/main/java/org/orgsync/core/engine/SyncResponse.java
+++ b/org-sync-core/src/main/java/org/orgsync/core/engine/SyncResponse.java
@@ -1,4 +1,6 @@
-package org.orgsync.core;
+package org.orgsync.core.engine;
+
+import org.orgsync.core.event.DomainEvent;
 
 import java.util.Collections;
 import java.util.List;

--- a/org-sync-core/src/main/java/org/orgsync/core/event/DomainEvent.java
+++ b/org-sync-core/src/main/java/org/orgsync/core/event/DomainEvent.java
@@ -1,4 +1,4 @@
-package org.orgsync.core;
+package org.orgsync.core.event;
 
 import java.util.Map;
 import java.util.Objects;

--- a/org-sync-core/src/main/java/org/orgsync/core/event/DomainEventPublisher.java
+++ b/org-sync-core/src/main/java/org/orgsync/core/event/DomainEventPublisher.java
@@ -1,4 +1,4 @@
-package org.orgsync.core;
+package org.orgsync.core.event;
 
 /**
  * Publishes synchronization domain events to the hosting application.

--- a/org-sync-core/src/main/java/org/orgsync/core/jdbc/JdbcApplier.java
+++ b/org-sync-core/src/main/java/org/orgsync/core/jdbc/JdbcApplier.java
@@ -1,4 +1,7 @@
-package org.orgsync.core;
+package org.orgsync.core.jdbc;
+
+import org.orgsync.core.engine.SyncResponse;
+import org.orgsync.core.spec.YamlSyncSpec;
 
 import javax.sql.DataSource;
 import java.util.Objects;

--- a/org-sync-core/src/main/java/org/orgsync/core/lock/LockManager.java
+++ b/org-sync-core/src/main/java/org/orgsync/core/lock/LockManager.java
@@ -1,4 +1,4 @@
-package org.orgsync.core;
+package org.orgsync.core.lock;
 
 /**
  * Coordinates company-level locking to ensure idempotent processing.

--- a/org-sync-core/src/main/java/org/orgsync/core/spec/SpecValidator.java
+++ b/org-sync-core/src/main/java/org/orgsync/core/spec/SpecValidator.java
@@ -1,4 +1,4 @@
-package org.orgsync.core;
+package org.orgsync.core.spec;
 
 import java.util.Map;
 

--- a/org-sync-core/src/main/java/org/orgsync/core/spec/YamlSpecLoader.java
+++ b/org-sync-core/src/main/java/org/orgsync/core/spec/YamlSpecLoader.java
@@ -1,4 +1,4 @@
-package org.orgsync.core;
+package org.orgsync.core.spec;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/org-sync-core/src/main/java/org/orgsync/core/spec/YamlSyncSpec.java
+++ b/org-sync-core/src/main/java/org/orgsync/core/spec/YamlSyncSpec.java
@@ -1,4 +1,4 @@
-package org.orgsync.core;
+package org.orgsync.core.spec;
 
 import java.util.Collections;
 import java.util.Map;

--- a/org-sync-core/src/main/java/org/orgsync/core/state/SyncStateRepository.java
+++ b/org-sync-core/src/main/java/org/orgsync/core/state/SyncStateRepository.java
@@ -1,4 +1,4 @@
-package org.orgsync.core;
+package org.orgsync.core.state;
 
 import java.util.Optional;
 

--- a/org-sync-spring-sample/src/main/java/org/orgsync/springsample/OrgSyncSpringSample.java
+++ b/org-sync-spring-sample/src/main/java/org/orgsync/springsample/OrgSyncSpringSample.java
@@ -1,16 +1,16 @@
 package org.orgsync.springsample;
 
-import org.orgsync.core.DomainEvent;
-import org.orgsync.core.DomainEventPublisher;
-import org.orgsync.core.LockManager;
-import org.orgsync.core.OrgChartClient;
-import org.orgsync.core.SyncEngine;
-import org.orgsync.core.SyncResponse;
-import org.orgsync.core.SyncStateRepository;
-import org.orgsync.core.YamlSyncSpec;
-import org.orgsync.spring.InMemoryLockManager;
-import org.orgsync.spring.OrgSyncConfiguration;
-import org.orgsync.spring.SpringDomainEventPublisher;
+import org.orgsync.core.client.OrgChartClient;
+import org.orgsync.core.engine.SyncEngine;
+import org.orgsync.core.engine.SyncResponse;
+import org.orgsync.core.event.DomainEvent;
+import org.orgsync.core.event.DomainEventPublisher;
+import org.orgsync.core.lock.LockManager;
+import org.orgsync.core.state.SyncStateRepository;
+import org.orgsync.core.spec.YamlSyncSpec;
+import org.orgsync.spring.config.OrgSyncConfiguration;
+import org.orgsync.spring.event.SpringDomainEventPublisher;
+import org.orgsync.spring.lock.InMemoryLockManager;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/org-sync-spring/src/main/java/org/orgsync/spring/config/OrgSyncConfiguration.java
+++ b/org-sync-spring/src/main/java/org/orgsync/spring/config/OrgSyncConfiguration.java
@@ -1,14 +1,15 @@
-package org.orgsync.spring;
+package org.orgsync.spring.config;
 
-import org.orgsync.core.DomainEventPublisher;
-import org.orgsync.core.JdbcApplier;
-import org.orgsync.core.LockManager;
-import org.orgsync.core.OrgChartClient;
-import org.orgsync.core.SpecValidator;
-import org.orgsync.core.SyncEngine;
-import org.orgsync.core.SyncStateRepository;
-import org.orgsync.core.YamlSpecLoader;
-import org.orgsync.core.YamlSyncSpec;
+import org.orgsync.core.client.OrgChartClient;
+import org.orgsync.core.engine.SyncEngine;
+import org.orgsync.core.event.DomainEventPublisher;
+import org.orgsync.core.jdbc.JdbcApplier;
+import org.orgsync.core.lock.LockManager;
+import org.orgsync.core.spec.SpecValidator;
+import org.orgsync.core.spec.YamlSpecLoader;
+import org.orgsync.core.spec.YamlSyncSpec;
+import org.orgsync.core.state.SyncStateRepository;
+import org.orgsync.spring.event.SpringDomainEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/org-sync-spring/src/main/java/org/orgsync/spring/event/SnapshotAppliedEvent.java
+++ b/org-sync-spring/src/main/java/org/orgsync/spring/event/SnapshotAppliedEvent.java
@@ -1,4 +1,4 @@
-package org.orgsync.spring;
+package org.orgsync.spring.event;
 
 import java.util.List;
 

--- a/org-sync-spring/src/main/java/org/orgsync/spring/event/SpringDomainEventPublisher.java
+++ b/org-sync-spring/src/main/java/org/orgsync/spring/event/SpringDomainEventPublisher.java
@@ -1,7 +1,7 @@
-package org.orgsync.spring;
+package org.orgsync.spring.event;
 
-import org.orgsync.core.DomainEvent;
-import org.orgsync.core.DomainEventPublisher;
+import org.orgsync.core.event.DomainEvent;
+import org.orgsync.core.event.DomainEventPublisher;
 import org.springframework.context.ApplicationEventPublisher;
 
 import java.util.Objects;

--- a/org-sync-spring/src/main/java/org/orgsync/spring/lock/InMemoryLockManager.java
+++ b/org-sync-spring/src/main/java/org/orgsync/spring/lock/InMemoryLockManager.java
@@ -1,6 +1,6 @@
-package org.orgsync.spring;
+package org.orgsync.spring.lock;
 
-import org.orgsync.core.LockManager;
+import org.orgsync.core.lock.LockManager;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;


### PR DESCRIPTION
## Summary
- organize org-sync-core classes into logical client, engine, event, jdbc, lock, spec, and state packages
- move org-sync-spring configuration, event, and lock classes into dedicated packages for readability
- update boot starter and sample applications to import the new package structure

## Testing
- Not run (gradle wrapper not available in repository)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a64f071f083278cd0a73fe6cc909d)