### PR TITLE
Use java-library plugin for subprojects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,9 @@ group = 'org.orgsync'
 version = '0.1.0-SNAPSHOT'
 
 subprojects {
-    apply plugin: 'java'
+    // Use the Java Library plugin so "api" configurations are available for modules
+    // that need to expose dependencies to their consumers.
+    apply plugin: 'java-library'
 
     group = rootProject.group
     version = rootProject.version


### PR DESCRIPTION
## Summary
- switch subprojects to the Java Library plugin so the `api` configuration is available
- ensures modules declaring `api` dependencies compile without configuration errors

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a6b47df54832797209b80a473934b)