### PR TITLE
Add RabbitMQ listener to trigger sync engine

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ project(':org-sync-spring') {
     dependencies {
         api project(':org-sync-core')
         implementation 'org.springframework:spring-context:6.1.6'
+        implementation 'org.springframework.amqp:spring-rabbit:3.1.6'
+        implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.4'
     }
 }
 
@@ -42,6 +44,7 @@ project(':org-sync-boot-starter') {
     dependencies {
         api project(':org-sync-spring')
         implementation 'org.springframework.boot:spring-boot-autoconfigure:3.2.5'
+        implementation 'org.springframework.boot:spring-boot-starter-amqp:3.2.5'
     }
 }
 
@@ -61,5 +64,6 @@ project(':org-sync-spring-sample') {
         implementation project(':org-sync-spring')
         implementation 'org.springframework:spring-context:6.1.6'
         implementation 'org.apache.commons:commons-dbcp2:2.12.0'
+        implementation 'org.springframework.amqp:spring-rabbit:3.1.6'
     }
 }

--- a/org-sync-boot-starter/src/main/java/org/orgsync/boot/OrgSyncAmqpAutoConfiguration.java
+++ b/org-sync-boot-starter/src/main/java/org/orgsync/boot/OrgSyncAmqpAutoConfiguration.java
@@ -1,0 +1,24 @@
+package org.orgsync.boot;
+
+import org.orgsync.spring.amqp.OrgSyncAmqpConfiguration;
+import org.springframework.amqp.rabbit.annotation.EnableRabbit;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Import;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.orgsync.core.engine.SyncEngine;
+
+/**
+ * Auto-configuration that connects RabbitMQ company change events to the sync engine.
+ */
+@AutoConfiguration
+@AutoConfigureAfter(RabbitAutoConfiguration.class)
+@ConditionalOnClass({EnableRabbit.class, RabbitListener.class})
+@ConditionalOnBean({ConnectionFactory.class, SyncEngine.class})
+@Import(OrgSyncAmqpConfiguration.class)
+public class OrgSyncAmqpAutoConfiguration {
+}

--- a/org-sync-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/org-sync-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 org.orgsync.boot.OrgSyncAutoConfiguration
+org.orgsync.boot.OrgSyncAmqpAutoConfiguration

--- a/org-sync-spec.md
+++ b/org-sync-spec.md
@@ -12,6 +12,13 @@
 * 저장 범위: 하위 서버는 **필요 도메인/필드/레코드만 저장**
 * 이벤트: 하위 서버 내부로 **도메인 생성/수정/삭제 + 필드 변경 이벤트** 발행 가능
 
+### RabbitMQ 연동 (회사 변경 이벤트)
+
+* 기본 큐 이름: `orgsync.company.changed` (환경변수/설정 `orgsync.amqp.company-change-queue`로 변경 가능)
+* 메시지 페이로드(JSON): `{ "companyId": "<회사 ID>" }`
+* 소비 로직: 큐 수신 시 해당 `companyId`로 `SyncEngine.synchronizeCompany` 호출
+* 메시지 컨버터: `Jackson2JsonMessageConverter`
+
 ---
 
 ## 1. 범위 / 비범위

--- a/org-sync-spring/src/main/java/org/orgsync/spring/amqp/CompanyChangeMessage.java
+++ b/org-sync-spring/src/main/java/org/orgsync/spring/amqp/CompanyChangeMessage.java
@@ -1,0 +1,7 @@
+package org.orgsync.spring.amqp;
+
+/**
+ * Payload for RabbitMQ company change events.
+ */
+public record CompanyChangeMessage(String companyId) {
+}

--- a/org-sync-spring/src/main/java/org/orgsync/spring/amqp/OrgSyncAmqpConfiguration.java
+++ b/org-sync-spring/src/main/java/org/orgsync/spring/amqp/OrgSyncAmqpConfiguration.java
@@ -1,0 +1,26 @@
+package org.orgsync.spring.amqp;
+
+import org.orgsync.core.engine.SyncEngine;
+import org.springframework.amqp.rabbit.annotation.EnableRabbit;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wires RabbitMQ listener infrastructure for org-sync.
+ */
+@Configuration
+@EnableRabbit
+public class OrgSyncAmqpConfiguration {
+
+    @Bean
+    public MessageConverter orgSyncRabbitMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    @Bean
+    public RabbitCompanyChangeListener rabbitCompanyChangeListener(SyncEngine syncEngine) {
+        return new RabbitCompanyChangeListener(syncEngine);
+    }
+}

--- a/org-sync-spring/src/main/java/org/orgsync/spring/amqp/RabbitCompanyChangeListener.java
+++ b/org-sync-spring/src/main/java/org/orgsync/spring/amqp/RabbitCompanyChangeListener.java
@@ -1,0 +1,25 @@
+package org.orgsync.spring.amqp;
+
+import org.orgsync.core.engine.SyncEngine;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.util.StringUtils;
+
+/**
+ * Listens for company change events on RabbitMQ and triggers synchronization.
+ */
+public class RabbitCompanyChangeListener {
+
+    private final SyncEngine syncEngine;
+
+    public RabbitCompanyChangeListener(SyncEngine syncEngine) {
+        this.syncEngine = syncEngine;
+    }
+
+    @RabbitListener(queues = "${orgsync.amqp.company-change-queue:orgsync.company.changed}")
+    public void onCompanyChange(CompanyChangeMessage message) {
+        if (message == null || !StringUtils.hasText(message.companyId())) {
+            throw new IllegalArgumentException("companyId is required in company change event");
+        }
+        syncEngine.synchronizeCompany(message.companyId());
+    }
+}


### PR DESCRIPTION
## Summary
- add RabbitMQ AMQP configuration and listener to trigger the sync engine on company change events
- wire Spring Boot auto-configuration for the listener and register new AMQP dependencies
- document the expected RabbitMQ queue, payload, and converter for the company change trigger

## Testing
- gradle :org-sync-spring:compileJava :org-sync-boot-starter:compileJava *(fails: Maven Central requests returned 403 in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a701a9fec83279c6234673f4c3f86)