### PR TITLE
Add configurable JDBC lock manager

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ project(':org-sync-spring') {
     dependencies {
         api project(':org-sync-core')
         implementation 'org.springframework:spring-context:6.1.6'
+        implementation 'org.springframework:spring-jdbc:6.1.6'
         implementation 'org.springframework.amqp:spring-rabbit:3.1.6'
         implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.4'
     }
@@ -43,6 +44,7 @@ project(':org-sync-boot-starter') {
 
     dependencies {
         api project(':org-sync-spring')
+        implementation 'org.springframework:spring-jdbc:6.1.6'
         implementation 'org.springframework.boot:spring-boot-autoconfigure:3.2.5'
         implementation 'org.springframework.boot:spring-boot-starter-amqp:3.2.5'
     }

--- a/org-sync-boot-starter/src/main/java/org/orgsync/boot/config/CompanyLockProperties.java
+++ b/org-sync-boot-starter/src/main/java/org/orgsync/boot/config/CompanyLockProperties.java
@@ -1,0 +1,36 @@
+package org.orgsync.boot.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configures how the JDBC lock manager finds the company row to lock.
+ */
+@ConfigurationProperties(prefix = "orgsync.lock.company")
+public class CompanyLockProperties {
+
+    /**
+     * Table name that stores company identifiers.
+     */
+    private String table = "company";
+
+    /**
+     * Column name that contains the company UUID.
+     */
+    private String uuidColumn = "uuid";
+
+    public String getTable() {
+        return table;
+    }
+
+    public void setTable(String table) {
+        this.table = table;
+    }
+
+    public String getUuidColumn() {
+        return uuidColumn;
+    }
+
+    public void setUuidColumn(String uuidColumn) {
+        this.uuidColumn = uuidColumn;
+    }
+}

--- a/org-sync-spec.md
+++ b/org-sync-spec.md
@@ -353,6 +353,12 @@ memberCompanyIds : text 또는 별도 매핑 테이블 권장
 * `UPDATE sync_state SET last_cursor=? WHERE company_id=? AND last_cursor=?`
 * 영향 row=0이면 커서 경합 → 중단/재시작
 
+DB 락용 테이블/컬럼은 설정으로 바꿀 수 있다.
+
+* 기본: `SELECT uuid FROM company WHERE uuid=:companyUuid FOR UPDATE`
+* 변경: `orgsync.lock.company.table`, `orgsync.lock.company.uuid-column`
+  * ex) `orgsync.lock.company.table=tenant_company`, `orgsync.lock.company.uuid-column=company_uuid`
+
 ### 7.3 Redis 분산락(옵션)
 
 * 목적: “중복 pull”을 줄이기 위한 single-flight 최적화

--- a/org-sync-spring/src/main/java/org/orgsync/spring/lock/JdbcLockManager.java
+++ b/org-sync-spring/src/main/java/org/orgsync/spring/lock/JdbcLockManager.java
@@ -1,0 +1,48 @@
+package org.orgsync.spring.lock;
+
+import org.orgsync.core.lock.LockManager;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Acquires a company-level lock using a database row lock (SELECT ... FOR UPDATE).
+ */
+public class JdbcLockManager implements LockManager {
+
+    private final TransactionTemplate transactionTemplate;
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+    private final String lockSql;
+
+    public JdbcLockManager(TransactionTemplate transactionTemplate,
+                           NamedParameterJdbcTemplate jdbcTemplate,
+                           String companyTableName,
+                           String companyUuidColumn) {
+        this.transactionTemplate = Objects.requireNonNull(transactionTemplate, "transactionTemplate");
+        this.jdbcTemplate = Objects.requireNonNull(jdbcTemplate, "jdbcTemplate");
+        if (companyTableName == null || companyTableName.isBlank()) {
+            throw new IllegalArgumentException("companyTableName must not be blank");
+        }
+        if (companyUuidColumn == null || companyUuidColumn.isBlank()) {
+            throw new IllegalArgumentException("companyUuidColumn must not be blank");
+        }
+        this.lockSql = String.format(
+                "SELECT %s FROM %s WHERE %s = :companyUuid FOR UPDATE",
+                companyUuidColumn,
+                companyTableName,
+                companyUuidColumn);
+    }
+
+    @Override
+    public void withLock(String companyUuid, Runnable runnable) {
+        transactionTemplate.executeWithoutResult(status -> {
+            boolean locked = jdbcTemplate.query(lockSql, Map.of("companyUuid", companyUuid), rs -> rs.next());
+            if (!locked) {
+                throw new IllegalStateException("No company row found for uuid=" + companyUuid);
+            }
+            runnable.run();
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- implement a JDBC-based LockManager that uses `SELECT ... FOR UPDATE` to serialize by company UUID
- expose `orgsync.lock.company` properties so the table and UUID column can be customized from configuration
- document the locking configuration and pull in Spring JDBC support for the new implementation

## Testing
- ./gradlew test *(fails: Gradle wrapper not present in repository)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cde5e98708327996a8bdc86d22f03)