### PR TITLE
Add org-sync prefix to JdbcLockManager errors

### DIFF
--- a/org-sync-spring/src/main/java/org/orgsync/spring/lock/JdbcLockManager.java
+++ b/org-sync-spring/src/main/java/org/orgsync/spring/lock/JdbcLockManager.java
@@ -26,10 +26,10 @@ public class JdbcLockManager implements LockManager {
         this.transactionTemplate = Objects.requireNonNull(transactionTemplate, "transactionTemplate");
         this.jdbcTemplate = Objects.requireNonNull(jdbcTemplate, "jdbcTemplate");
         if (companyTableName == null || companyTableName.isBlank()) {
-            throw new IllegalArgumentException("companyTableName must not be blank");
+            throw new IllegalArgumentException("[org-sync] companyTableName must not be blank");
         }
         if (companyUuidColumn == null || companyUuidColumn.isBlank()) {
-            throw new IllegalArgumentException("companyUuidColumn must not be blank");
+            throw new IllegalArgumentException("[org-sync] companyUuidColumn must not be blank");
         }
         this.lockSql = String.format(
                 "SELECT %s FROM %s WHERE %s = :companyUuid FOR UPDATE",
@@ -45,7 +45,7 @@ public class JdbcLockManager implements LockManager {
                 jdbcTemplate.query(lockSql, Map.of("companyUuid", companyUuid), ResultSet::next));
 
             if (!locked) {
-                throw new IllegalStateException("No company row found for uuid=" + companyUuid);
+                throw new IllegalStateException("[org-sync] No company row found for uuid=" + companyUuid);
             }
             runnable.run();
         });


### PR DESCRIPTION
## Summary
- add the `[org-sync]` prefix to JdbcLockManager exception messages to follow the error message specification

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ce1fe4fc88327a315ad86abe0d596)