### PR TITLE
Exclude sample modules from Gradle build (build only library modules)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,31 +73,3 @@ project(':org-sync-boot-starter') {
         api 'org.springframework.boot:spring-boot-starter-amqp:3.2.5'
     }
 }
-
-project(':org-sync-boot-sample') {
-    apply plugin: 'org.springframework.boot'
-    apply plugin: 'io.spring.dependency-management'
-
-    dependencies {
-        implementation project(':org-sync-boot-starter')
-        implementation 'org.springframework.boot:spring-boot-starter:3.2.5'
-        implementation 'org.springframework.boot:spring-boot-starter-web'
-        implementation 'org.springframework.boot:spring-boot-starter-data-jpa:3.2.5'
-        implementation 'org.apache.commons:commons-dbcp2:2.12.0'
-        runtimeOnly 'com.h2database:h2:2.2.224'
-    }
-}
-
-project(':org-sync-spring-sample') {
-    dependencies {
-        implementation project(':org-sync-spring')
-        implementation 'org.springframework:spring-context:6.1.6'
-        implementation 'org.apache.commons:commons-dbcp2:2.12.0'
-        implementation 'org.springframework.amqp:spring-rabbit:3.1.6'
-        implementation 'org.springframework.data:spring-data-jpa:3.2.5'
-        implementation 'org.springframework:spring-orm:6.1.6'
-        implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.4'
-        implementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'
-        runtimeOnly 'com.h2database:h2:2.2.224'
-    }
-}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
 rootProject.name = 'org-sync'
-include 'org-sync-core', 'org-sync-spring', 'org-sync-boot-starter', 'org-sync-boot-sample', 'org-sync-spring-sample'
+include 'org-sync-core', 'org-sync-spring', 'org-sync-boot-starter'


### PR DESCRIPTION
### Motivation
- JitPack builds were failing due to a missing `SampleOrgChartClient` in the sample module, and the intention is to publish only the library modules `org-sync-core`, `org-sync-spring`, and `org-sync-boot-starter`.

### Description
- Update `settings.gradle` to include only `org-sync-core`, `org-sync-spring`, and `org-sync-boot-starter`.
- Remove the `project(':org-sync-boot-sample')` and `project(':org-sync-spring-sample')` blocks from `build.gradle` so sample modules are no longer compiled or published.
- Preserve `maven-publish` configuration for the three library modules so they remain publishable.

### Testing
- No automated builds or tests were executed after this change.
- The previous automated JitPack build failed with a compilation error in `org-sync-spring-sample` (missing `SampleOrgChartClient`) before these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968690d25ec8327af52c4a615cd2d4b)